### PR TITLE
useAsyncEffect

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-tippy": "^1.4.0",
     "rxjs": "6.6.7",
     "source-map-explorer": "^2.5.2",
+    "use-async-effect": "^2.2.3",
     "waait": "^1.0.5",
     "web-vitals": "^1.0.1",
     "web3": "^1.5.0"

--- a/src/elements/swapWidget/SwapWidget.tsx
+++ b/src/elements/swapWidget/SwapWidget.tsx
@@ -9,6 +9,7 @@ import { useAppSelector } from 'redux/index';
 import { ethToken, wethToken } from 'services/web3/config';
 import { Insight } from 'elements/swapInsights/Insight';
 import { IntoTheBlock, intoTheBlockByToken } from 'services/api/intoTheBlock';
+import { useAsyncEffect } from 'use-async-effect'
 
 interface SwapWidgetProps {
   isLimit: boolean;
@@ -30,17 +31,22 @@ export const SwapWidget = ({ isLimit, setIsLimit }: SwapWidgetProps) => {
     loadSwapData(dispatch);
   }, [dispatch]);
 
-  useEffect(() => {
-    (async () => {
-      if (fromToken)
-        setFromTokenITB(await intoTheBlockByToken(fromToken.symbol));
-    })();
+  useAsyncEffect(async (isMounted) => {
+    if (fromToken) {
+      const data = await intoTheBlockByToken(fromToken.symbol);
+      if (isMounted()) {
+        setFromTokenITB(data);
+      }
+    }
   }, [fromToken]);
 
-  useEffect(() => {
-    (async () => {
-      if (toToken) setToTokenITB(await intoTheBlockByToken(toToken.symbol));
-    })();
+  useAsyncEffect(async (isMounted) => {
+    if (toToken) {
+      const data = await intoTheBlockByToken(toToken.symbol);
+      if (isMounted()) {
+        setToTokenITB(data);
+      }
+    }
   }, [toToken]);
 
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17140,6 +17140,11 @@ usb@^1.6.0:
     node-addon-api "3.0.2"
     prebuild-install "^5.3.3"
 
+use-async-effect@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/use-async-effect/-/use-async-effect-2.2.3.tgz#752cc065b7d002c177e754cd0624a166018341bc"
+  integrity sha512-l/FSqFyqPwhpDJseKyJ9/FZi3PBat2LOcspAqFJznm6H8pgWs67WIjMDr1s3WFBd6cS9zvQrySX0HyHfZi/Upg==
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"


### PR DESCRIPTION
Allows cleaner use of writing async functions inside useEffects and the ability to check if we're still mounted to protect against unwanted side effects should there be a race condition problem.