### PR TITLE
check error code for possible rejected transaction

### DIFF
--- a/src/elements/swapMarket/SwapMarket.tsx
+++ b/src/elements/swapMarket/SwapMarket.tsx
@@ -222,7 +222,7 @@ export const SwapMarket = ({
       );
     } catch (e) {
       console.error('Swap failed with error: ', e);
-      if (e.message.includes('User denied transaction signature'))
+      if (e.code === 4001)
         dispatch(
           addNotification({
             type: NotificationType.error,


### PR DESCRIPTION
https://github.com/bancorprotocol/webapp-v2/issues/274

when rejecting transactions
- on mobile error is "User rejected transaction" and code 4001
- on desktop error is "User denied transaction signature" and code 4001

Documentation from eth says 4001 is for rejected transactions.
https://eips.ethereum.org/EIPS/eip-1193#provider-errors

So given that i think it is safe to check just the error code, when error is thrown.